### PR TITLE
Amend feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "jekyll", "3.4.3"
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-   gem "jekyll-feed", "~> 0.6"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/_config.yml
+++ b/_config.yml
@@ -21,8 +21,6 @@ url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings
 markdown: kramdown
-gems:
-  - jekyll-feed
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,7 +20,7 @@
 
     <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="https://feeds.mozilla-podcasts.org/irl">
 
     <script src="{{ "/assets/js/pre-render.js" | relative_url }}"></script>
     <script src="{{ "/assets/js/mozilla.dnt-helper.js" | relative_url }}"></script>


### PR DESCRIPTION
Currently your website is pointing to a feed generated by Jekyll, while you are using FeedPress to host your curated feed. I've amended the site meta data to point to FeedPress so subscribing will be a bit easier and attempted to drop jekyll-feed that now unused.