### PR TITLE
[fix bug 1382828] Display episode descriptions.

### DIFF
--- a/_includes/episode-module.html
+++ b/_includes/episode-module.html
@@ -29,6 +29,10 @@
 
     <iframe class="episode-player" src="{{ episode.embed }}?style=light" seamless="" scrolling="no" width="100%" height="36px" frameborder="0"></iframe>
 
+    <div class="episode-description">
+        {{ episode.description | markdownify }}
+    </div>
+
     <!-- the following are presented in modal windows -->
     <div class="modal-content-wrapper">
         <div class="episode-subscribe-links" id="episode-{{ episode.number }}-subscribe-links">

--- a/_sass/irlpodcast.scss
+++ b/_sass/irlpodcast.scss
@@ -177,12 +177,17 @@ a:visited:hover {
 }
 
 .episode {
+    .episode-description {
+        margin-top: 20px;
+    }
+
     @media #{$mq-tablet} {
         display: grid;
         grid-template: repeat(4, auto) / 300px auto;
         grid-template-areas: "logo title"
                              "logo links"
-                             "logo player";
+                             "logo player"
+                             "description description";
 
         // align image to top right side of grid area
         .episode-image {
@@ -201,6 +206,10 @@ a:visited:hover {
 
         .episode-player {
             grid-area: player;
+        }
+
+        .episode-description {
+            grid-area: description;
         }
     }
 }
@@ -274,6 +283,16 @@ a:visited:hover {
 
     .episode-player {
         display: none;
+    }
+
+    .episode-description {
+        // do not display description for mobile on home page
+        display: none;
+
+        @media #{$mq-tablet} {
+            display: block;
+            padding-left: 100px; // line up with right-aligned image
+        }
     }
 }
 


### PR DESCRIPTION
Displays episode descriptions on home page when `$mq-tablet` or wider. Displays descriptions on episode pages for all screen sizes.