### PR TITLE
Adds 'bundle install' command prior to jekyll build in build.sh.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -7,6 +7,6 @@ docker run --rm --label=jekyll \
     --volume=$(pwd)/release:/tmp/build \
     -e JEKYLL_ENV=production \
     jekyll/jekyll \
-    bash -c "jekyll build --config _config.yml,_config-build-prod.yml --destination /tmp/build && chown -R jekyll /srv/jekyll"
+    bash -c "bundle install && jekyll build --config _config.yml,_config-build-prod.yml --destination /tmp/build && chown -R jekyll /srv/jekyll"
 # dir is owned by root and jenkins unable to delete without chown
 # jekyll is UID 1000 within container which matches jenkins UID in host


### PR DESCRIPTION
The official jekyll image has had issues beginning 2017-08-31. The latest
update (as of 2017-09-01 11:00 CDT) fixes all issues *except* that 'bundle
install' is never run. This patch runs 'bundle install' prior to running
'jekyll build`.

If/when the jekyll image is fixed "for good", we can probably revert this
patch, but it shouldn't cause issues being left in. ('bundle install' may
get run twice.)