### PR TITLE
Fix docker image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 jekyll:
   # image specifically for GitHub pages
-  image: jekyll/jekyll:pages
+  image: jekyll/jekyll:builder
   # --future will show future-dated posts
   command: jekyll serve --watch --future
   # map port in container to local port


### PR DESCRIPTION
Fixes: https://gist.github.com/alexgibson/d14170ccc127a1d1477bc05c8cb46364

It looks like the `jekyll:pages` image tag is no more? (thanks @metadave)