### PR TITLE
Add “Mozilla Corporation” to site description

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -17,13 +17,13 @@
                     </p>
 
                     <p>
-                        IRL is an original podcast from Mozilla.
+                        IRL is an original podcast from Mozilla Corporation.
                     </p>
                 </div>
 
                 <section class="subscribe-links-wrapper">
                     <h4>Subscribe for free!</h4>
-                    
+
                     {{ partial "subscribe-links.html" (dict "subscribeLinksID" "subscribe-links-primary") }}
                 </section>
             </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
     <meta property="og:image:width" content="{{ $.Scratch.Get "ogImageWidth" }}">
     <meta property="og:image:height" content="{{ $.Scratch.Get "ogImageHeight" }}">
     <meta property="og:title" content="{{ $.Scratch.Get "ogTitle" | default "IRL Podcast" }}">
-    <meta property="og:description" content="{{ .Page.Params.ogDescription | default "Veronica Belmont explores real stories of life online – and real talk about how we can all keep the Internet healthy, weird and wonderful. IRL is an original podcast from Mozilla." }}">
+    <meta property="og:description" content="{{ .Page.Params.ogDescription | default "Veronica Belmont explores real stories of life online – and real talk about how we can all keep the Internet healthy, weird and wonderful. IRL is an original podcast from Mozilla Corporation." }}">
     <meta name="twitter:card" content="summary_large_image">
 
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="/images/favicon/favicon-180x180.png">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,7 +22,7 @@
                     </p>
 
                     <p>
-                        IRL is an original podcast from Mozilla.
+                        IRL is an original podcast from Mozilla Corporation.
                     </p>
                 </div>
 


### PR DESCRIPTION
To make a distinction between MoCo and MoFo, as requested by the legal team. See https://github.com/mozilla/bedrock/issues/6306

It should be noted that there are many other instances of "a podcast by Mozilla" in audio transcripts, and those can't be changed obviously since the audio can't be changed, but just changing the global description should satisfy legal's requirements.