### PR TITLE
Ignore slack errors during deployment

### DIFF
--- a/bin/slack-notify.sh
+++ b/bin/slack-notify.sh
@@ -67,4 +67,4 @@ else
     exit 1
 fi
 
-slack-cli -d "${CHANNEL}" "${MESSAGE}"
+slack-cli -d "${CHANNEL}" "${MESSAGE}" || true


### PR DESCRIPTION
These can happen but should not interfere with deployment