### PR TITLE
Use the page description as title, if present.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,7 +37,7 @@
     <link rel="icon" type="image/png" sizes="196x196" href="/images/favicon/favicon-196x196.png">
     <link rel="shortcut icon" href="/images/favicon/favicon.ico">
 
-    <title>{{ .Page.Title | default .Site.Title }}</title>
+    <title>{{ .Page.Params.ogDescription | default .Page.Title | default .Site.Title }}</title>
     <meta name="description" content="{{ htmlEscape (.Page.Params.description | default .Site.Params.description | markdownify) | truncate 160 }}">
 
     <meta name="apple-itunes-app" content="app-id=1247652431, affiliate-data=at=1010lbVy&amp;ct=mozilla_smart_banner">


### PR DESCRIPTION
It keeps to fallback onto page title and site title.