### PR TITLE
Improve time to first meaningful paint using font-display: swap

### DIFF
--- a/src/scss/includes/fonts/_franklin-gothic.scss
+++ b/src/scss/includes/fonts/_franklin-gothic.scss
@@ -7,6 +7,7 @@
     font-family: 'FranklinGothic';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/fonts/franklingothic-book.woff2') format('woff2'),
          url('/fonts/franklingothic-book.woff') format('woff');
 }
@@ -15,6 +16,7 @@
     font-family: 'FranklinGothic';
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/fonts/franklingothic-demi.woff2') format('woff2'),
          url('/fonts/franklingothic-demi.woff') format('woff');
 }


### PR DESCRIPTION
Adds `font-display: swap` to ensure text is visible whilst web fonts are still loading on slower connections.