### PR TITLE
Run gulp container as current user. Fix #175

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,12 +4,17 @@ set -ex
 cd "$(dirname ${BASH_SOURCE[0]})"/..
 mkdir -p ./release
 
+# adapted from https://lebenplusplus.de/2018/03/15/how-to-run-npm-install-as-non-root-from-a-docker-container/
+echo "node:x:$(id -u):$(id -g)::/home/node:/bin/bash" > /tmp/fake-passwd
+
 # let gulp build the assets
 docker run --rm --label=gulp \
-    --volume=$(pwd):/srv \
-    --entrypoint /bin/bash \
-    huli/gulp \
-    -c "/entrypoint.sh build --production && chown $(id -u):$(id -g) . -R"
+       --volume=$(pwd):/srv \
+       --volume=/tmp/fake-passwd:/etc/passwd \
+       --volume=/tmp:/home/node \
+       -u $(id -u):$(id -g) \
+       huli/gulp \
+       build --production
 
 # and then let hugo build the site
 docker run --rm --label=hugo \


### PR DESCRIPTION
Adapted solution from https://lebenplusplus.de/2018/03/15/how-to-run-npm-install-as-non-root-from-a-docker-container/