### PR TITLE
Wrong firefox link in intro.html

### DIFF
--- a/layouts/partials/intro.html
+++ b/layouts/partials/intro.html
@@ -2,7 +2,7 @@
     <div class="c-intro-main">
 
         <div class="c-intro-logo">
-            <a href="https://www.mozilla.org/de/firefox/"><img src="/images/firefox.png" alt="Firefox" width="93" height="47"></a>
+            <a href="https://www.mozilla.org/firefox/"><img src="/images/firefox.png" alt="Firefox" width="93" height="47"></a>
         </div>
 
         <h1 class="c-intro-title">IRL: Online Life is Real Life</h1>


### PR DESCRIPTION
irlpodcast.org links in the intro to www.mozilla.org/de/firefox/ but its better to send users to the locale free redirect, so they get the page in their language.