### PR TITLE
Pad bottom of listener survey banner

### DIFF
--- a/src/scss/survey.scss
+++ b/src/scss/survey.scss
@@ -6,11 +6,11 @@
 
 .survey-banner {
     @include gradient-horizontal($start-color: #ff00ff, $end-color: #2e2aa6);
-    bottom: 0;
+    bottom: -50px;
     color: #fff;
     display: none;
     left: 0;
-    padding-bottom: 10px;
+    padding-bottom: 60px;
     position: fixed;
     text-align: center;
     width: 100%;


### PR DESCRIPTION
When the survey banner pops up it goes above the bottom of the window and snaps back, and for a brief instant you can see the page behind the bottom edge of the banner. This adds a bit of padding and negative bottom position so when it pops up it appears to continue past the edge.